### PR TITLE
Persist user language selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,22 +48,31 @@
     <script>
         // Language detection and redirection
         document.addEventListener('DOMContentLoaded', function() {
-            const userLang = navigator.language || navigator.userLanguage;
-            let targetPage = 'index_en.html'; // Default to English
-            
-            // Determine which language page to redirect to
-            if (userLang.startsWith('ru')) {
-                targetPage = 'index_ru.html';
-            } else if (userLang.startsWith('th')) {
-                targetPage = 'index_th.html';
-            } else if (userLang.startsWith('zh')) {
-                targetPage = 'index_zh.html';
-            } else if (userLang.startsWith('es')) {
-                targetPage = 'index_es.html';
-            } else if (userLang.startsWith('ar')) {
-                targetPage = 'index_ar.html';
+            const savedLang = localStorage.getItem('lang');
+            const validLangs = ['en', 'ru', 'th', 'zh', 'es', 'ar'];
+            let targetPage;
+
+            if (savedLang && validLangs.includes(savedLang)) {
+                // Use saved language preference
+                targetPage = `index_${savedLang}.html`;
+            } else {
+                // Determine language based on browser settings
+                const userLang = navigator.language || navigator.userLanguage;
+                targetPage = 'index_en.html'; // Default to English
+
+                if (userLang.startsWith('ru')) {
+                    targetPage = 'index_ru.html';
+                } else if (userLang.startsWith('th')) {
+                    targetPage = 'index_th.html';
+                } else if (userLang.startsWith('zh')) {
+                    targetPage = 'index_zh.html';
+                } else if (userLang.startsWith('es')) {
+                    targetPage = 'index_es.html';
+                } else if (userLang.startsWith('ar')) {
+                    targetPage = 'index_ar.html';
+                }
             }
-            
+
             // Redirect to the appropriate language page
             window.location.href = targetPage;
         });

--- a/index_ar.html
+++ b/index_ar.html
@@ -633,6 +633,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'ar');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;

--- a/index_en.html
+++ b/index_en.html
@@ -638,6 +638,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'en');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;

--- a/index_es.html
+++ b/index_es.html
@@ -638,6 +638,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'es');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;

--- a/index_ru.html
+++ b/index_ru.html
@@ -638,6 +638,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'ru');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;

--- a/index_th.html
+++ b/index_th.html
@@ -638,6 +638,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'th');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;

--- a/index_zh.html
+++ b/index_zh.html
@@ -638,6 +638,7 @@
     <!-- JavaScript for Star Animation and Theme Switching -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            localStorage.setItem('lang', 'zh');
             // Theme toggle functionality
             const toggleBtn = document.getElementById('theme-toggle');
             const body = document.body;


### PR DESCRIPTION
## Summary
- Remember the user's chosen language in localStorage on every localized page
- Redirect to saved language before browser detection in the root index page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689744217d648332a2fe170abdd9e596